### PR TITLE
Update README.md. Write unit tests- broken link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Programmers burn out from just such cycles.
 Breaking out requires an outside influence. We found the outside influence we needed in a simple testing framework that lets us do a little testing that
 makes a big difference.
 
-[Source](http://junit.sourceforge.net/doc/testinfected/testing.htm)
+- JUnit 3.8.x.
 
 
 #### [Without unit tests] You're not refactoring, you're just changing shit. — Hamlet D'Arcy


### PR DESCRIPTION
Broken link for the source. https://web.archive.org/web/20180212235316/http://junit.sourceforge.net/doc/testinfected/testing.htm probably has the original article.

The new link for JUnit might be: https://junit.org/ but I noticed that it promotes some other link for the war in Ukraine right now. This one may be preferred: https://war.ukraine.ua/ This is why I recommend not referring in this case.

I also tried thinking of some way to prevent broken links in the future (testing), but this could maybe be impossible, as sites may serve custom informative pages for broken links.